### PR TITLE
do not allow searches with no CURIE

### DIFF
--- a/src/Components/Query/Query.js
+++ b/src/Components/Query/Query.js
@@ -133,7 +133,7 @@ const Query = ({results, loading, presetDisease, presetType}) => {
 
   // Validation function for submission
   const validateSubmission = useCallback(() => {
-    if(selectedItem === null) {
+    if(selectedItem === null || selectedItem.id === "") {
       setIsError(true);
       setErrorText("No term selected, please select a valid term.");
       return;


### PR DESCRIPTION
Ideally the saved query should include the CURIE, but it does not. We need to look into this issue in more detail but this fix will work for now.