### PR TITLE
fix bug with non-unique publications

### DIFF
--- a/src/Components/Modals/EvidenceModal.js
+++ b/src/Components/Modals/EvidenceModal.js
@@ -260,13 +260,14 @@ const EvidenceModal = ({isOpen, onClose, currentEvidence, item, isAll, edgeGroup
                   <div className={styles.evidenceItems}>
                     {
                       clinicalTrials.current.map((item, i)=> {
+                        const edge = Object.values(item.edges)[0];
                         return (
                           <div className={styles.evidenceItem} key={i}>
                             <span className={`${styles.cell} ${styles.relationship} relationship`}>
                               {
-                                item.edge &&
+                                edge &&
                                 <span>
-                                  <span>{item.edge.subject}</span><strong>{item.edge.predicates[0]}</strong><span>{item.edge.object}</span>
+                                  <span>{edge.subject}</span><strong>{edge.predicate}</strong><span>{edge.object}</span>
                                 </span>
                               }
                             </span>
@@ -328,13 +329,14 @@ const EvidenceModal = ({isOpen, onClose, currentEvidence, item, isAll, edgeGroup
                       <div className={styles.evidenceItems} >
                         {
                           displayedPubmedEvidence.map((item, i)=> {
+                            const edge = Object.values(item.edges)[0];
                             return (
                               <div className={styles.evidenceItem} key={i}>
                                 <span className={`${styles.cell} ${styles.relationship} relationship`}>
                                   {
-                                    item.edge &&
+                                    edge &&
                                     <span>
-                                      <span>{item.edge.subject}</span><strong>{item.edge.predicates[0]}</strong><span>{item.edge.object}</span>
+                                      <span>{edge.subject}</span><strong>{edge.predicate}</strong><span>{edge.object}</span>
                                     </span>
                                   }
                                 </span>
@@ -419,11 +421,12 @@ const EvidenceModal = ({isOpen, onClose, currentEvidence, item, isAll, edgeGroup
                   <div className={styles.evidenceItems}>
                     {
                       sources.map((src, i) => { 
-                        let subjectName = capitalizeAllWords(src.edge.subject);
-                        let predicateName = capitalizeAllWords(src.edge.predicates[0]);
-                        let objectName = capitalizeAllWords(src.edge.object);
-                        let name = (!Array.isArray(src) && typeof src === 'object') ? src.name: '';
-                        let url = (!Array.isArray(src) && typeof src === 'object') ? src.url: src;
+                        const edge = Object.values(src.edges)[0];
+                        const subjectName = capitalizeAllWords(edge.subject);
+                        const predicateName = capitalizeAllWords(edge.predicate);
+                        const objectName = capitalizeAllWords(edge.object);
+                        const name = (!Array.isArray(src) && typeof src === 'object') ? src.name: '';
+                        const url = (!Array.isArray(src) && typeof src === 'object') ? src.url: src;
                         return(
                           <div className={styles.evidenceItem}>
                             { !isAll &&

--- a/src/Components/ResultsItem/ResultsItem.js
+++ b/src/Components/ResultsItem/ResultsItem.js
@@ -34,20 +34,10 @@ const ResultsItem = ({key, item, type, activateEvidence, activeStringFilters, ra
   const handleEdgeSpecificEvidence = (edgeGroup) => {
     const filterEvidenceObjs = (objs, selectedEdge, container) => {
       for (const obj of objs) {
-        let include = true;
-        // check for subject match
-        if(obj.edge.subject.toLowerCase() !== selectedEdge.subject.names[0].toLowerCase())
-          include = false;
-        // check for predicate match
-        if(!obj.edge.predicates.map((p) => p.toLowerCase()).includes(selectedEdge.predicate.toLowerCase()))
-          include = false;
-        // check for object match
-        if(obj.edge.object.toLowerCase() !== selectedEdge.object.names[0].toLowerCase())
-          include = false;
-
-        if(include) {
+        if (obj.edges[selectedEdge.id] !== undefined) {
           const includedObj = cloneDeep(obj);
-          includedObj.edge.predicates = [selectedEdge.predicate];
+          includedObj.edges = {};
+          includedObj.edges[selectedEdge.id] = obj.edges[selectedEdge.id];
           container.push(includedObj);
         }
       }

--- a/src/Utilities/resultsFormattingFunctions.js
+++ b/src/Utilities/resultsFormattingFunctions.js
@@ -14,17 +14,16 @@ const getFormattedEvidence = (paths, results) => {
       let evidenceObj = container[id];
       if (evidenceObj === undefined) {
         evidenceObj = constructor(obj);
-        let object = item.edges[0].object;
-        let subject = item.edges[0].subject;
-        evidenceObj.edge = {
-          subject: capitalizeAllWords(subject.names[0]),
-          predicates: item.predicates,
-          object: capitalizeAllWords(object.names[0])
-        };
+        evidenceObj.edges = {};
         container[id] = evidenceObj;
-      } else {
-        evidenceObj.edge.predicates.push(...item.predicates);
       }
+
+      const eid = item.edges[0].id;
+      evidenceObj.edges[eid] = {
+        subject: item.edges[0].subject.names[0],
+        predicate: item.edges[0].predicate,
+        object: item.edges[0].object.names[0]
+      };
     }
   };
 
@@ -187,7 +186,7 @@ const getFormattedPaths = (rawPathIds, results) => {
           formattedPath.subgraph[i] = {
             category: 'predicate',
             predicates: [pred],
-            edges: [{object: edge.object, predicate: pred, subject: edge.subject, provenance: edge.provenance}],
+            edges: [{id: eid, object: edge.object, predicate: pred, subject: edge.subject, provenance: edge.provenance}],
             publications: edge.publications
           };
           if(edge.provenance !== undefined) {


### PR DESCRIPTION
This was caused when generating the FormattedEvidence objects. Basically we were only keeping track of the first edge in the path that had the publication. This made us ping-pong between a bug where we did not show evidence for the edge or we showed the incorrect relationship, but the right evidence.

TAQA Issue: [https://github.com/NCATSTranslator/Feedback/issues/214](https://github.com/NCATSTranslator/Feedback/issues/214)